### PR TITLE
fix(add): include scopes with # or / when rewriting

### DIFF
--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -280,7 +280,7 @@ Behavior depends on what the <path> directory contains and if you provided an [u
       }
 
       if (!message.startsWith(`Merge`) && !message.startsWith(`Revert`)) {
-        const commitHeadRegex = /^([\w-]+)(?:[[(]([\w -]+)[\])])?: ?(.*)/;
+        const commitHeadRegex = /^([\w-]+)(?:[[(]([\w -#/]+)[\])])?: ?(.*)/;
         const msgLines = message.split(`\n`);
         const parsedHead = commitHeadRegex.exec(message);
         const msg = {

--- a/tap-snapshots/test-tap-commands-add.ts-TAP.test.js
+++ b/tap-snapshots/test-tap-commands-add.ts-TAP.test.js
@@ -19,6 +19,8 @@ exports[`test/tap/commands/add.ts TAP add command run() remote > commits 1`] = `
 *    Merge remote-tracking branch test/monocli-add-test
 |\\  
 | *  (test/monocli-add-test) chore(test): Move all files into packages/foo
+| *  chore(test/foo): baz
+| *  feat(#1): bar
 | *  stub repo
 *  stub repo
 `
@@ -32,12 +34,16 @@ exports[`test/tap/commands/add.ts TAP add command run() rewrite > commits 1`] = 
 *    Merge remote-tracking branch test/monocli-add-test
 |\\  
 | *  (test/monocli-add-test) chore(test): Move all files into packages/foo
+| *  chore(test): baz
+| *  feat(test): bar
 | *  chore(test): stub repo
 *  stub repo
 `
 
 exports[`test/tap/commands/add.ts TAP add command run() rewrite > output 1`] = `
 chore(test): stub repo
+feat(test): bar
+chore(test): baz
 chore(test): Move all files into packages/foo
 monocli notice you should now check everything is ok and then run the update command
 `
@@ -47,6 +53,8 @@ exports[`test/tap/commands/add.ts TAP add command run() with submodule with url 
 *    Merge remote-tracking branch subproject/monocli-add-subproject
 |\\  
 | *  (subproject/monocli-add-subproject) chore(subproject): Move all files into packages/subproject
+| *  chore(test/foo): baz
+| *  feat(#1): bar
 | *  stub repo
 *  chore: delete submodule at packages/subproject
 *  submodule
@@ -63,6 +71,8 @@ exports[`test/tap/commands/add.ts TAP add command run() with submodule without u
 *    Merge remote-tracking branch subproject/monocli-add-subproject
 |\\  
 | *  (subproject/monocli-add-subproject) chore(subproject): Move all files into packages/subproject
+| *  chore(test/foo): baz
+| *  feat(#1): bar
 | *  stub repo
 *  chore: delete submodule at packages/subproject
 *  submodule


### PR DESCRIPTION
`#` and `/` weren't included in the regex

the previous behavior when using `--rewrite` was :
`type(#1): msg` :arrow_right:  `chore(scope): type(#1): msg`