### PR TITLE
(spush) save branch before force push

### DIFF
--- a/src/commands/spull.ts
+++ b/src/commands/spull.ts
@@ -18,23 +18,16 @@ export class SPullCommand extends MonorepoCommand {
   > {
     branch = branch || `master`;
     const { remoteUrl } = this.getProjectRemote(directory, urlOption);
-    // TODO: check for existing remote
-    try {
-      await this.monorepo.repository.git(`subtree`, [
-        `pull`,
-        `--prefix`,
-        directory,
-        remoteUrl,
-        branch
-      ]);
-      log.notice(
-        `success`,
-        `local directory ${directory} successfully updated from ${remoteUrl}`
-      );
-    } catch (e) {
-      throw new Error(
-        `Pull failed. Did you forget to add this subproject before?`
-      );
-    }
+    await this.monorepo.repository.git(`subtree`, [
+      `pull`,
+      `--prefix`,
+      directory,
+      remoteUrl,
+      branch
+    ]);
+    log.notice(
+      `success`,
+      `local directory ${directory} successfully updated from ${remoteUrl}`
+    );
   }
 }

--- a/tap-snapshots/test-tap-commands-spush.ts-TAP.test.js
+++ b/tap-snapshots/test-tap-commands-spush.ts-TAP.test.js
@@ -117,18 +117,16 @@ exports[`test/tap/commands/spush.ts TAP > updated config 4`] = `
 }
 `
 
-exports[`test/tap/commands/spush.ts TAP spush command with url argument with conflict do nothing > ouput 1`] = `
-monocli ERR! git Push to [[TEST DIRECTORY]]/tap/commands/spush/conflict/sub master branch failed!
-monocli ERR! git To [[TMP DIRECTORY]]/[[TIMESTAMP]]
-monocli ERR! git  ! [rejected]        monocli-spush-proj-[[TIMESTAMP]] -> master (fetch first)
-monocli ERR! git error: failed to push some refs to '[[TMP DIRECTORY]]/[[TIMESTAMP]]'
-monocli ERR! git hint: Updates were rejected because the remote contains work that you do
-monocli ERR! git hint: not have locally. This is usually caused by another repository pushing
-monocli ERR! git hint: to the same ref. You may want to first integrate the remote changes
-monocli ERR! git hint: (e.g., 'git pull ...') before pushing again.
-monocli ERR! git hint: See the 'Note about fast-forwards' in 'git push --help' for details.
+exports[`test/tap/commands/spush.ts TAP spush command with url argument with conflict --force > output 1`] = `
+monocli WARN git Push to [[TEST DIRECTORY]]/tap/commands/spush/force/sub master branch failed!
+monocli notice branch master saved on [[TEST DIRECTORY]]/tap/commands/spush/force/sub as save-master
+monocli notice local changes successfully pushed to [[TEST DIRECTORY]]/tap/commands/spush/force/sub/master
+`
 
-monocli ERR! Push to [[TEST DIRECTORY]]/tap/commands/spush/conflict/sub master branch failed! Go to [[TMP DIRECTORY]]/[[TIMESTAMP]] in order to resolve this conflict.
+exports[`test/tap/commands/spush.ts TAP spush command with url argument with conflict do nothing > ouput 1`] = `
+monocli WARN git Push to [[TEST DIRECTORY]]/tap/commands/spush/conflict/sub master branch failed!
+
+monocli ERR! Go to [[TMP DIRECTORY]]/[[TIMESTAMP]] in order to resolve this conflict.
 `
 
 exports[`test/tap/commands/spush.ts TAP spush command with url argument with conflict new branch > output 1`] = `

--- a/tap-snapshots/test-tap-commands-spush.ts-TAP.test.js
+++ b/tap-snapshots/test-tap-commands-spush.ts-TAP.test.js
@@ -5,118 +5,6 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
-exports[`test/tap/commands/spush.ts TAP > monorepo commits 1`] = `
-docs: README
-
-feat(proj): foo.txt
-
-stub repo
-`
-
-exports[`test/tap/commands/spush.ts TAP > monorepo commits 2`] = `
-docs: README
-
-feat(proj): foo.txt
-
-stub repo
-`
-
-exports[`test/tap/commands/spush.ts TAP > monorepo commits 3`] = `
-docs: README
-
-feat(proj): foo.txt
-
-stub repo
-`
-
-exports[`test/tap/commands/spush.ts TAP > monorepo commits 4`] = `
-docs: README
-
-feat(proj): foo.txt
-
-stub repo
-`
-
-exports[`test/tap/commands/spush.ts TAP > output 1`] = `
-monocli ERR! url no remote url was given for subproj
-`
-
-exports[`test/tap/commands/spush.ts TAP > output 2`] = `
-monocli notice remote subrepo successfully updated
-`
-
-exports[`test/tap/commands/spush.ts TAP > output 3`] = `
-monocli notice remote subrepo successfully updated
-`
-
-exports[`test/tap/commands/spush.ts TAP > output 4`] = `
-monocli notice remote subrepo successfully updated
-`
-
-exports[`test/tap/commands/spush.ts TAP > subrepo commits 1`] = `
-Error: fatal: your current branch 'master' does not have any commits yet {
-  "code": 128,
-}
-`
-
-exports[`test/tap/commands/spush.ts TAP > subrepo commits 2`] = `
-feat(proj): foo.txt
-`
-
-exports[`test/tap/commands/spush.ts TAP > subrepo commits 3`] = `
-feat(proj): foo.txt
-`
-
-exports[`test/tap/commands/spush.ts TAP > subrepo commits 4`] = `
-feat(proj): foo.txt
-`
-
-exports[`test/tap/commands/spush.ts TAP > updated config 1`] = `
-{
-  "projects": [
-    {
-      "scope": "proj",
-      "directory": "subproj"
-    }
-  ]
-}
-`
-
-exports[`test/tap/commands/spush.ts TAP > updated config 2`] = `
-{
-  "projects": [
-    {
-      "scope": "proj",
-      "directory": "subproj"
-    }
-  ]
-}
-`
-
-exports[`test/tap/commands/spush.ts TAP > updated config 3`] = `
-{
-  "projects": [
-    {
-      "scope": "proj",
-      "directory": "subproj",
-      "url": "../sub"
-    }
-  ]
-}
-`
-
-exports[`test/tap/commands/spush.ts TAP > updated config 4`] = `
-{
-  "projects": [
-    {
-      "scope": "proj",
-      "directory": "subproj",
-      "url": "../sub"
-    }
-  ]
-}
-`
-
 exports[`test/tap/commands/spush.ts TAP spush command with url argument with conflict --force > output 1`] = `
 monocli WARN git Push to [[TEST DIRECTORY]]/tap/commands/spush/force/sub master branch failed!
 monocli notice branch master saved on [[TEST DIRECTORY]]/tap/commands/spush/force/sub as save-master
@@ -131,4 +19,116 @@ monocli ERR! Go to [[TMP DIRECTORY]]/[[TIMESTAMP]] in order to resolve this conf
 
 exports[`test/tap/commands/spush.ts TAP spush command with url argument with conflict new branch > output 1`] = `
 monocli notice remote subrepo successfully updated
+`
+
+exports[`test/tap/commands/spush.ts TAP spush command with url argument without conflict > monorepo commits 1`] = `
+docs: README
+
+feat(proj): foo.txt
+
+stub repo
+`
+
+exports[`test/tap/commands/spush.ts TAP spush command with url argument without conflict > output 1`] = `
+monocli notice remote subrepo successfully updated
+`
+
+exports[`test/tap/commands/spush.ts TAP spush command with url argument without conflict > subrepo commits 1`] = `
+feat(proj): foo.txt
+`
+
+exports[`test/tap/commands/spush.ts TAP spush command with url argument without conflict > updated config 1`] = `
+{
+  "projects": [
+    {
+      "scope": "proj",
+      "directory": "subproj"
+    }
+  ]
+}
+`
+
+exports[`test/tap/commands/spush.ts TAP spush command with url in config > monorepo commits 1`] = `
+docs: README
+
+feat(proj): foo.txt
+
+stub repo
+`
+
+exports[`test/tap/commands/spush.ts TAP spush command with url in config > output 1`] = `
+monocli notice remote subrepo successfully updated
+`
+
+exports[`test/tap/commands/spush.ts TAP spush command with url in config > subrepo commits 1`] = `
+feat(proj): foo.txt
+`
+
+exports[`test/tap/commands/spush.ts TAP spush command with url in config > updated config 1`] = `
+{
+  "projects": [
+    {
+      "scope": "proj",
+      "directory": "subproj",
+      "url": "../sub"
+    }
+  ]
+}
+`
+
+exports[`test/tap/commands/spush.ts TAP spush command with url in config and argument > monorepo commits 1`] = `
+docs: README
+
+feat(proj): foo.txt
+
+stub repo
+`
+
+exports[`test/tap/commands/spush.ts TAP spush command with url in config and argument > output 1`] = `
+monocli notice remote subrepo successfully updated
+`
+
+exports[`test/tap/commands/spush.ts TAP spush command with url in config and argument > subrepo commits 1`] = `
+feat(proj): foo.txt
+`
+
+exports[`test/tap/commands/spush.ts TAP spush command with url in config and argument > updated config 1`] = `
+{
+  "projects": [
+    {
+      "scope": "proj",
+      "directory": "subproj",
+      "url": "../sub"
+    }
+  ]
+}
+`
+
+exports[`test/tap/commands/spush.ts TAP spush command without remote url > monorepo commits 1`] = `
+docs: README
+
+feat(proj): foo.txt
+
+stub repo
+`
+
+exports[`test/tap/commands/spush.ts TAP spush command without remote url > output 1`] = `
+monocli ERR! url no remote url was given for subproj
+`
+
+exports[`test/tap/commands/spush.ts TAP spush command without remote url > subrepo commits 1`] = `
+Error: fatal: your current branch 'master' does not have any commits yet {
+  "code": 128,
+}
+`
+
+exports[`test/tap/commands/spush.ts TAP spush command without remote url > updated config 1`] = `
+{
+  "projects": [
+    {
+      "scope": "proj",
+      "directory": "subproj"
+    }
+  ]
+}
 `

--- a/test/tap/commands/spush.ts
+++ b/test/tap/commands/spush.ts
@@ -83,7 +83,7 @@ async function setup(
 }
 
 async function assert(
-  x: Test,
+  t: Test,
   output: string,
   testFiles: TestFiles
 ): Promise<void> {


### PR DESCRIPTION
if the branch already exists in remote and push fails, a`save-<branch name>` branch is created from `<branch name>` before force push